### PR TITLE
Add subdirs for external/{iproute2,iptables}

### DIFF
--- a/core/main.mk
+++ b/core/main.mk
@@ -511,6 +511,8 @@ subdirs := \
 	external/giflib \
 	external/gtest \
 	external/icu/icu4c \
+	external/iproute2 \
+	external/iptables \
 	external/jemalloc \
 	external/jhead \
 	external/jpeg \


### PR DESCRIPTION
These projects are needed by qcomm's netmgrd.