### PR TITLE
core_base.mk: add CAMERA_SERVICE_WANT_UBUNTU_HEADERS

### DIFF
--- a/target/product/core_base.mk
+++ b/target/product/core_base.mk
@@ -90,4 +90,9 @@ PRODUCT_PACKAGES += \
     direct_ubuntu_application_sensors_for_hybris_test \
     direct_ubuntu_application_gps_c_api_for_hybris_test
 
+# Our Android tree has Ubuntu's camera service headers. Set this so that
+# video recording with compat layer works.
+# Not sure if this is the best place to do it.
+CAMERA_SERVICE_WANT_UBUNTU_HEADERS := 1
+
 $(call inherit-product, $(SRC_TARGET_DIR)/product/core_minimal.mk)


### PR DESCRIPTION
Fixes video recording for AAL backend after upgrading libhybris.

May be related to https://github.com/ubports/ubuntu-touch/issues/1521

Change-Id: Ibe578d59d470ea87bb62274ff3373fa6e2f82be3